### PR TITLE
Add ability to export directly to "lab" files

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -58,11 +58,17 @@ It has the following advantages:
     Parameters that need to be specified:
     - `--ckpt`: (must be specified) The path to the model weights;
     - `--folder`: The folder where the data to be aligned is stored (default is `segments`);
+    - `--out_formats`: The annotation format of the inferred files, multiple formats can be specified, separated by commas (default is `TextGrid,htk`).
+
     - `--dictionary`: The dictionary file (default is `dictionary/opencpop-extension.txt`);
 
     ```bash
-    python infer.py --ckpt checkpoint_path --folder segments_path --dictionary dictionary_path
+    python infer.py --ckpt checkpoint_path --folder segments_path --dictionary dictionary_path -out_formats output_format1,output_format2...
     ```
+5. Retrieve the Final Annotation
+
+   The final annotation is saved in a folder, the name of which is the annotation format you have chosen. This folder is located in the same directory as the wav files used for inference.
+
 ### Advanced Features
 
    - Using a custom g2p instead of a dictionary

--- a/README_zh.MD
+++ b/README_zh.MD
@@ -58,11 +58,16 @@ SOFA(Singing-Oriented Forced Aligner)是一个专为歌声设计的强制对齐�
     需要指定的参数：
     - `--ckpt`：（必须指定）模型权重路径；
     - `--folder`：存放待对齐数据的文件夹​（默认为`segments`）；
+    - `--out_formats`：推理出来的文件的标注格式，可指定多个，使用逗号分隔（默认为`TextGrid,htk`）
     - `--dictionary`：字典文件​（默认为`dictionary/opencpop-extension.txt`​）；
 
     ```bash
-    python infer.py -c checkpoint_path -s segments_path -d dictionary_path
+    python infer.py -c checkpoint_path -s segments_path -d dictionary_path -of output_format1,output_format2...
     ```
+5. 获取最终标注
+
+    最终的标注保存在文件夹中，文件夹的名称是你选择的标注格式，这个文件夹的位置和推理所用的wav文件处于同一个文件夹中。
+
 ### 高级功能
 
    - 使用自定义的g2p，而不是使用词典

--- a/infer.py
+++ b/infer.py
@@ -106,11 +106,11 @@ def save_textgrids(predictions):
 
         tg.append(word_tier)
         tg.append(ph_tier)
-        tg.write(wav_path.with_suffix(".TextGrid"))
+        tg.write(wav_path.parent / "TextGrid" / wav_path.stem + ".TextGrid")
 
 
 def save_htk(predictions):
-    print("Saving Labels...")
+    print("Saving htk labels...")
 
     for (
         wav_path,
@@ -125,7 +125,11 @@ def save_htk(predictions):
             start_time = int(float(start) * 10000000)
             end_time = int(float(end) * 10000000)
             label += f"{start_time} {end_time} {ph}\n"
-        with open(wav_path.with_suffix(".lab"), "w+", encoding="utf-8") as f:
+        with open(
+            wav_path.parent / "htk" / "phones" / wav_path.stem + ".lab",
+            "w",
+            encoding="utf-8",
+        ) as f:
             f.write(label)
             f.close()
 

--- a/infer.py
+++ b/infer.py
@@ -133,6 +133,19 @@ def save_htk(predictions):
             f.write(label)
             f.close()
 
+        label = ""
+        for word, (start, end) in zip(word_seq, word_intervals):
+            start_time = int(float(start) * 10000000)
+            end_time = int(float(end) * 10000000)
+            label += f"{start_time} {end_time} {word}\n"
+        with open(
+            wav_path.parent / "htk" / "words" / wav_path.stem + ".lab",
+            "w",
+            encoding="utf-8",
+        ) as f:
+            f.write(label)
+            f.close()
+
 
 @click.command()
 @click.option(

--- a/infer.py
+++ b/infer.py
@@ -106,7 +106,12 @@ def save_textgrids(predictions):
 
         tg.append(word_tier)
         tg.append(ph_tier)
-        tg.write(wav_path.parent / "TextGrid" / wav_path.stem + ".TextGrid")
+
+        label_path = (
+            wav_path.parent / "TextGrid" / wav_path.with_suffix(".TextGrid").name
+        )
+        label_path.parent.mkdir(parents=True, exist_ok=True)
+        tg.write(label_path)
 
 
 def save_htk(predictions):
@@ -125,11 +130,11 @@ def save_htk(predictions):
             start_time = int(float(start) * 10000000)
             end_time = int(float(end) * 10000000)
             label += f"{start_time} {end_time} {ph}\n"
-        with open(
-            wav_path.parent / "htk" / "phones" / wav_path.stem + ".lab",
-            "w",
-            encoding="utf-8",
-        ) as f:
+        label_path = (
+            wav_path.parent / "htk" / "phones" / wav_path.with_suffix(".lab").name
+        )
+        label_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(label_path, "w", encoding="utf-8") as f:
             f.write(label)
             f.close()
 
@@ -138,11 +143,11 @@ def save_htk(predictions):
             start_time = int(float(start) * 10000000)
             end_time = int(float(end) * 10000000)
             label += f"{start_time} {end_time} {word}\n"
-        with open(
-            wav_path.parent / "htk" / "words" / wav_path.stem + ".lab",
-            "w",
-            encoding="utf-8",
-        ) as f:
+        label_path = (
+            wav_path.parent / "htk" / "words" / wav_path.with_suffix(".lab").name
+        )
+        label_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(label_path, "w", encoding="utf-8") as f:
             f.write(label)
             f.close()
 
@@ -192,7 +197,7 @@ def main(ckpt, folder, mode, g2p, ap_detector, out_formats, **kwargs):
         g2p += "G2P"
     g2p_class = getattr(modules.g2p, g2p)
     grapheme_to_phoneme = g2p_class(**kwargs)
-    out_formats = out_formats.split(",").strip()
+    out_formats = [i.strip() for i in out_formats.split(",")]
 
     if not ap_detector.endswith("APDetector"):
         ap_detector += "APDetector"

--- a/infer.py
+++ b/infer.py
@@ -102,11 +102,32 @@ def save_textgrids(predictions):
             word_tier.add(start, end, word)
 
         for ph, (start, end) in zip(ph_seq, ph_intervals):
-            ph_tier.add(minTime=start, maxTime=end, mark=ph)
+            ph_tier.add(minTime=float(start), maxTime=end, mark=ph)
 
         tg.append(word_tier)
         tg.append(ph_tier)
         tg.write(wav_path.with_suffix(".TextGrid"))
+
+def save_labels(predictions):
+    print("Saving Labels...")
+
+    for (
+        wav_path,
+        wav_length,
+        ph_seq,
+        ph_intervals,
+        word_seq,
+        word_intervals,
+    ) in predictions:
+        label = ''
+        for ph, (start, end) in zip(ph_seq, ph_intervals):
+            start_time = int(float(start) * 10000000)
+            end_time = int(float(end) * 10000000)
+            label += f"{start_time} {end_time} {ph}\n"
+        with open(wav_path.with_suffix(".lab"), "w+", encoding='utf-8') as f:
+            f.write(label)
+            f.close()
+
 
 
 @click.command()
@@ -141,7 +162,15 @@ def save_textgrids(predictions):
     type=str,
     help="(only used when --g2p=='Dictionary') path to the dictionary",
 )
-def main(ckpt, folder, mode, g2p, ap_detector, **kwargs):
+@click.option(
+    "--out_format",
+    "-of",
+    default="TextGrid",
+    required=False,
+    type=click.Choice(['TextGrid', 'lab']),
+    help="Type of output file"
+)
+def main(ckpt, folder, mode, g2p, ap_detector, out_format, **kwargs):
     if not g2p.endswith("G2P"):
         g2p += "G2P"
     g2p_class = getattr(modules.g2p, g2p)
@@ -162,7 +191,10 @@ def main(ckpt, folder, mode, g2p, ap_detector, **kwargs):
 
     predictions = get_AP.process(predictions)
     predictions = post_processing(predictions)
-    save_textgrids(predictions)
+    if out_format == 'TextGrid':
+        save_textgrids(predictions)
+    elif out_format == 'lab':
+        save_labels(predictions)
     # save_htk(output, predictions)
     # save_transcriptions(output, predictions)
     print("Output files are saved to the same folder as the input wav files.")

--- a/infer.py
+++ b/infer.py
@@ -109,7 +109,7 @@ def save_textgrids(predictions):
         tg.write(wav_path.with_suffix(".TextGrid"))
 
 
-def save_labels(predictions):
+def save_htk(predictions):
     print("Saving Labels...")
 
     for (
@@ -200,7 +200,7 @@ def main(ckpt, folder, mode, g2p, ap_detector, out_formats, **kwargs):
         or "nnsvs" in out_formats
         or "sinsy" in out_formats
     ):
-        save_labels(predictions)
+        save_htk(predictions)
     # save_transcriptions(output, predictions)
     print("Output files are saved to the same folder as the input wav files.")
 

--- a/infer.py
+++ b/infer.py
@@ -108,6 +108,7 @@ def save_textgrids(predictions):
         tg.append(ph_tier)
         tg.write(wav_path.with_suffix(".TextGrid"))
 
+
 def save_labels(predictions):
     print("Saving Labels...")
 
@@ -119,15 +120,14 @@ def save_labels(predictions):
         word_seq,
         word_intervals,
     ) in predictions:
-        label = ''
+        label = ""
         for ph, (start, end) in zip(ph_seq, ph_intervals):
             start_time = int(float(start) * 10000000)
             end_time = int(float(end) * 10000000)
             label += f"{start_time} {end_time} {ph}\n"
-        with open(wav_path.with_suffix(".lab"), "w+", encoding='utf-8') as f:
+        with open(wav_path.with_suffix(".lab"), "w+", encoding="utf-8") as f:
             f.write(label)
             f.close()
-
 
 
 @click.command()
@@ -163,18 +163,19 @@ def save_labels(predictions):
     help="(only used when --g2p=='Dictionary') path to the dictionary",
 )
 @click.option(
-    "--out_format",
+    "--out_formats",
     "-of",
-    default="TextGrid",
+    default="TextGrid,htk",
     required=False,
-    type=click.Choice(['TextGrid', 'lab']),
-    help="Type of output file"
+    type=str,
+    help="Types of output file, separated by comma. Supported types: TextGrid(textgrid,praat), htk(lab,nnsvs,sinsy)",
 )
-def main(ckpt, folder, mode, g2p, ap_detector, out_format, **kwargs):
+def main(ckpt, folder, mode, g2p, ap_detector, out_formats, **kwargs):
     if not g2p.endswith("G2P"):
         g2p += "G2P"
     g2p_class = getattr(modules.g2p, g2p)
     grapheme_to_phoneme = g2p_class(**kwargs)
+    out_formats = out_formats.split(",").strip()
 
     if not ap_detector.endswith("APDetector"):
         ap_detector += "APDetector"
@@ -191,11 +192,15 @@ def main(ckpt, folder, mode, g2p, ap_detector, out_format, **kwargs):
 
     predictions = get_AP.process(predictions)
     predictions = post_processing(predictions)
-    if out_format == 'TextGrid':
+    if "TextGrid" in out_formats or "textgrid" in out_formats or "praat" in out_formats:
         save_textgrids(predictions)
-    elif out_format == 'lab':
+    if (
+        "htk" in out_formats
+        or "lab" in out_formats
+        or "nnsvs" in out_formats
+        or "sinsy" in out_formats
+    ):
         save_labels(predictions)
-    # save_htk(output, predictions)
     # save_transcriptions(output, predictions)
     print("Output files are saved to the same folder as the input wav files.")
 


### PR DESCRIPTION
Added command line argument "out_format"
- Options: TextGrid + lab. TextGrid is the same output as the original, lab will overwrite lab files with NNSVS style lab files. Saves a conversion step!