### PR TITLE
Read transcripts in 'utf-8'

### DIFF
--- a/modules/g2p/base_g2p.py
+++ b/modules/g2p/base_g2p.py
@@ -46,7 +46,7 @@ class BaseG2P:
         for wav_path in wav_paths:
             try:
                 if wav_path.with_suffix(".lab").exists():
-                    with open(wav_path.with_suffix(".lab"), "r") as f:
+                    with open(wav_path.with_suffix(".lab"), "r", encoding="utf-8") as f:
                         lab_text = f.read().strip()
                     ph_seq, word_seq, ph_idx_to_word_idx = self(lab_text)
                     dataset.append((wav_path, ph_seq, word_seq, ph_idx_to_word_idx))


### PR DESCRIPTION
load ".lab" transcriptions with encoding 'utf-8', I've gotten a few unicode errors from running SOFA and this seems to fix it.